### PR TITLE
Fix mixed content warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,7 +310,7 @@ body { font-family: 'Montserrat', sans-serif; }
 <section id="contacto" class="py-12 bg-gray-100">
   <div class="max-w-5xl mx-auto px-4">
     <h2 class="text-center text-3xl logo-font mb-4">Contáctanos</h2>
-    <form class="max-w-xl mx-auto space-y-4" action="mailto:villalaperla1@gmail.com" method="post" enctype="text/plain">
+    <form class="max-w-xl mx-auto space-y-4" action="https://formsubmit.co/villalaperla1@gmail.com" method="POST">
     <input type="text" name="nombre" placeholder="Nombre" required class="w-full border rounded p-2" />
     <input type="email" name="correo" placeholder="Correo" required class="w-full border rounded p-2" />
     <textarea name="mensaje" placeholder="Mensaje" required class="w-full border rounded p-2"></textarea>


### PR DESCRIPTION
## Summary
- use HTTPS formsubmit endpoint instead of `mailto:` for the contact form

## Testing
- `tidy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d833f43d48325a50a9ec0f4cf4b27