### PR TITLE
Reemplazar menú lateral con hamburguesa

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,13 +43,13 @@ body { font-family: 'Montserrat', sans-serif; }
 </head>
 <body class="bg-gray-50 text-gray-800">
 <div id="top"></div>
-<button id="open-menu" class="fixed top-4 left-4 z-50 bg-amber-500 text-white p-2 rounded lg:hidden">
+<button id="open-menu" class="fixed top-4 left-4 z-50 bg-amber-500 text-white p-2 rounded">
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-6 h-6">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
   </svg>
 </button>
-<nav id="main-nav" class="fixed top-0 left-0 w-56 h-full bg-[#f5f5dc] shadow transform transition-transform -translate-x-full lg:translate-x-0 lg:block z-40">
-  <button id="close-menu" class="absolute top-4 right-4 lg:hidden text-xl">&times;</button>
+<nav id="main-nav" class="fixed top-0 left-0 w-56 h-full bg-[#f5f5dc] shadow transform transition-transform -translate-x-full z-40">
+  <button id="close-menu" class="absolute top-4 right-4 text-xl">&times;</button>
   <ul class="mt-16 space-y-4 p-4">
     <li><a href="#sobre" class="flex items-center px-2 py-1 rounded hover:bg-amber-200"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 mr-2"><path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L15.586 11H3a1 1 0 110-2h12.586l-5.293-5.293a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>Sobre la Villa</a></li>
     <li><a href="#instalaciones" class="flex items-center px-2 py-1 rounded hover:bg-amber-200"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4 mr-2"><path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L15.586 11H3a1 1 0 110-2h12.586l-5.293-5.293a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>Instalaciones</a></li>


### PR DESCRIPTION
## Summary
- cambia `index.html` para que el menú lateral siempre esté oculto y se abra con botón hamburguesa

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686da8a18a5c8325b9768fa4c7f6710f