### PR TITLE
Add Firestore storage for comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,7 +346,18 @@ body { font-family: 'Montserrat', sans-serif; }
   <p>Síguenos en <a href="https://www.facebook.com/VillaLaPerlaAgs" class="underline">Facebook</a></p>
   <p class="mt-2">© 2025 Villa La Perla - Calvillo, Aguascalientes</p>
 </footer>
-<script>
+  <!-- Firebase -->
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+  <script>
+    // TODO: Reemplaza con la configuración de tu proyecto
+    const firebaseConfig = {
+      apiKey: "YOUR_API_KEY",
+      authDomain: "YOUR_AUTH_DOMAIN",
+      projectId: "YOUR_PROJECT_ID",
+    };
+    firebase.initializeApp(firebaseConfig);
+    const db = firebase.firestore();
   document.addEventListener('DOMContentLoaded', function () {
     new Swiper('.gallery-swiper', {
       effect: 'coverflow',
@@ -384,15 +395,20 @@ body { font-family: 'Montserrat', sans-serif; }
         testimonials: [],
         nuevo: {nombre: '', mensaje: '', calificacion: 5},
         async init(){
-          const res = await fetch('testimonials.json');
-          const defaults = await res.json();
-          const stored = localStorage.getItem('testimonials');
-          this.testimonials = stored ? JSON.parse(stored) : defaults;
+          const snapshot = await db.collection('testimonials').get();
+          if(snapshot.empty){
+            const res = await fetch('testimonials.json');
+            const defaults = await res.json();
+            this.testimonials = defaults;
+            defaults.forEach(t => db.collection('testimonials').add(t));
+          } else {
+            this.testimonials = snapshot.docs.map(doc => doc.data());
+          }
         },
-        addTestimonial(){
+        async addTestimonial(){
           if(this.nuevo.nombre && this.nuevo.mensaje && this.nuevo.calificacion){
+            await db.collection('testimonials').add({...this.nuevo});
             this.testimonials.push({...this.nuevo});
-            localStorage.setItem('testimonials', JSON.stringify(this.testimonials));
             this.nuevo = {nombre:'',mensaje:'',calificacion:5};
           }
         }


### PR DESCRIPTION
## Summary
- integrate Firebase Firestore SDK
- update testimonial app to read and write testimonials from Firestore

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_686db37436148325b3fa91c50978bac8