### PR TITLE
Fix Google Maps script async parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -486,6 +486,6 @@ function calcularRuta(){
 }
 document.getElementById("obtener-direcciones").addEventListener("click",e=>{e.preventDefault();calcularRuta();});
 </script>
-<script async defer loading="async" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDGPhkcGn5alswcJ9ClJ__pXe9WfFE0K3c&libraries=places&callback=initMap"></script>
+<script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDGPhkcGn5alswcJ9ClJ__pXe9WfFE0K3c&libraries=places&callback=initMap&loading=async"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update Google Maps API script tag to use `loading=async`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ea5fe5d5883259ad93f443f284edf