### PR TITLE
Fix Google Maps button width

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,9 +368,9 @@ body { font-family: 'Montserrat', sans-serif; }
   <div class="max-w-5xl mx-auto px-4 text-center space-y-4">
     <h2 class="text-center text-3xl logo-font mb-4">¿Cómo llegar?</h2>
     <p class="text-center mb-4">Utiliza la aplicación Google Maps para obtener la ruta.</p>
-  <a href="https://maps.app.goo.gl/yNJiRgzKyytseDHg9" target="_blank" rel="noopener" class="btn-flashy w-auto mx-auto flex items-center justify-center bg-white border border-gray-300 px-4 py-2 rounded shadow space-x-2">
-  <img src="google-maps.svg" alt="Google Maps" class="w-6 h-6">
-  <span>Abrir en Google Maps</span>
+  <a href="https://maps.app.goo.gl/yNJiRgzKyytseDHg9" target="_blank" rel="noopener" class="btn-flashy inline-flex items-center justify-center bg-white border border-gray-300 px-4 py-2 rounded shadow space-x-2">
+    <img src="google-maps.svg" alt="Google Maps" class="w-6 h-6">
+    <span>Abrir en Google Maps</span>
   </a>
     <p class="text-center mb-4">Escribe la dirección de tu punto de partida<br>por ejemplo:<br> "Av. Constitución 123, Centro, Calvillo, Ags.".</p>
     <div class="flex justify-center space-x-2">


### PR DESCRIPTION
## Summary
- make the Google Maps button use `inline-flex` so it only spans the text and icon

## Testing
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_686ec2e1e48c83258a0bb5413614cb57