### PR TITLE
Add sitemap for Google Search Console

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://villalaperla.github.io/</loc>
+    <lastmod>2025-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add `sitemap.xml` for SEO submission in Google Search Console

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686fda3ac37883259ce65d7fa82bff2b